### PR TITLE
Use stable HighCharts CDN

### DIFF
--- a/Graphs.js
+++ b/Graphs.js
@@ -2,7 +2,7 @@
 var head = document.getElementsByTagName('head')[0];
 var script = document.createElement('script');
 script.type = 'text/javascript';
-script.src = 'https://github.highcharts.com/highcharts.js';
+script.src = 'https://code.highcharts.com/highcharts.js';
 head.appendChild(script);
 
 


### PR DESCRIPTION
The github.highcharts.com cdn redirects to HTTP instead of HTTPS, causing my browser to ignore the insecure script, but the main CDN works fine

Using Chrome Version 48.0.2564.103 (64-bit)
