### PR TITLE
Equipment -- Change Weapon Purchase Conditions

### DIFF
--- a/modules/equipment.js
+++ b/modules/equipment.js
@@ -373,7 +373,7 @@ function autoLevelEquipment() {
                 document.getElementById(eqName).style.border = '2px solid red';
             }
             //If we're considering an attack item, we want to buy weapons if we don't have enough damage, or if we don't need health (so we default to buying some damage)
-            if (getPageSetting('BuyWeapons') && DaThing.Stat == 'attack' && (!enoughDamageE || enoughHealthE)) {
+            if (getPageSetting('BuyWeapons') && DaThing.Stat == 'attack' && (!enoughDamageE)) {
                 if (DaThing.Equip && !Best[stat].Wall && canAffordBuilding(eqName, null, null, true)) {
                     debug('Leveling equipment ' + eqName, "equips", '*upload3');
                     buyEquipment(eqName, null, true);


### PR DESCRIPTION
Changed condition for buying weapons. Removed 'enough health' as a valid purchase condition. This was causing the system to purchase weapons when damage wasn't required, which is a waste of iron.

This isn't a perfect fix, but it's definitely a step forwards.

Edit:

Whoops. Merged to the wrong branch. My bad. You guys can have this one if you want.